### PR TITLE
Fix Value method for NullRawMessage

### DIFF
--- a/json.go
+++ b/json.go
@@ -36,5 +36,5 @@ func (n NullRawMessage) Value() (driver.Value, error) {
 	if !n.Valid {
 		return nil, nil
 	}
-	return n.RawMessage, nil
+	return []byte(n.RawMessage), nil
 }

--- a/tests/inet_test.go
+++ b/tests/inet_test.go
@@ -35,6 +35,9 @@ func TestInet(t *testing.T) {
 			if diff := cmp.Diff(addr, ip.IPNet.String()); diff != "" {
 				t.Errorf("IPNet mismatch (-want +got):\n%s", diff)
 			}
+			if _, err := db.Exec(`SELECT $1`, ip); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 	t.Run("NULL", func(t *testing.T) {
@@ -44,6 +47,9 @@ func TestInet(t *testing.T) {
 		}
 		if diff := cmp.Diff(false, ip.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
+		}
+		if _, err := db.Exec(`SELECT $1`, ip); err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/tests/inet_test.go
+++ b/tests/inet_test.go
@@ -35,7 +35,7 @@ func TestInet(t *testing.T) {
 			if diff := cmp.Diff(addr, ip.IPNet.String()); diff != "" {
 				t.Errorf("IPNet mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, ip); err != nil {
+			if _, err := db.Exec(`SELECT abbrev($1)`, ip); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -48,7 +48,7 @@ func TestInet(t *testing.T) {
 		if diff := cmp.Diff(false, ip.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT $1`, ip); err != nil {
+		if _, err := db.Exec(`SELECT abbrev($1)`, ip); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -87,7 +87,7 @@ func TestJSONRawMessage(t *testing.T) {
 		if diff := cmp.Diff(false, n.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT jsonb_typeof($1)`, n); err != nil {
+		if _, err := db.Exec(`SELECT $1`, n); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -32,6 +32,9 @@ func TestJSONRawMessage(t *testing.T) {
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n.RawMessage)); diff != "" {
 				t.Errorf("json mismatch (-want +got):\n%s", diff)
 			}
+			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+				t.Fatal(err)
+			}
 			if err := db.QueryRow(fmt.Sprintf(`SELECT '%s'::jsonb`, payload)).Scan(&n); err != nil {
 				t.Fatal(err)
 			}
@@ -40,6 +43,9 @@ func TestJSONRawMessage(t *testing.T) {
 			}
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n.RawMessage)); diff != "" {
 				t.Errorf("jsonb mismatch (-want +got):\n%s", diff)
+			}
+			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+				t.Fatal(err)
 			}
 		})
 		t.Run("/stdlib/"+payload, func(t *testing.T) {
@@ -50,11 +56,17 @@ func TestJSONRawMessage(t *testing.T) {
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n)); diff != "" {
 				t.Errorf("json mismatch (-want +got):\n%s", diff)
 			}
+			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+				t.Fatal(err)
+			}
 			if err := db.QueryRow(fmt.Sprintf(`SELECT '%s'::jsonb`, payload)).Scan(&n); err != nil {
 				t.Fatal(err)
 			}
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n)); diff != "" {
 				t.Errorf("jsonb mismatch (-want +got):\n%s", diff)
+			}
+			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
@@ -66,11 +78,17 @@ func TestJSONRawMessage(t *testing.T) {
 		if diff := cmp.Diff(false, n.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
+		if _, err := db.Exec(`SELECT $1`, n); err != nil {
+			t.Fatal(err)
+		}
 		if err := db.QueryRow(`SELECT NULL::jsonb`).Scan(&n); err != nil {
 			t.Fatal(err)
 		}
 		if diff := cmp.Diff(false, n.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
+		}
+		if _, err := db.Exec(`SELECT $1`, n); err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -32,7 +32,7 @@ func TestJSONRawMessage(t *testing.T) {
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n.RawMessage)); diff != "" {
 				t.Errorf("json mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+			if _, err := db.Exec(`SELECT json_typeof($1)`, n); err != nil {
 				t.Fatal(err)
 			}
 			if err := db.QueryRow(fmt.Sprintf(`SELECT '%s'::jsonb`, payload)).Scan(&n); err != nil {
@@ -44,7 +44,7 @@ func TestJSONRawMessage(t *testing.T) {
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n.RawMessage)); diff != "" {
 				t.Errorf("jsonb mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+			if _, err := db.Exec(`SELECT jsonb_typeof($1)`, n); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -56,7 +56,7 @@ func TestJSONRawMessage(t *testing.T) {
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n)); diff != "" {
 				t.Errorf("json mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+			if _, err := db.Exec(`SELECT json_typeof($1)`, n); err != nil {
 				t.Fatal(err)
 			}
 			if err := db.QueryRow(fmt.Sprintf(`SELECT '%s'::jsonb`, payload)).Scan(&n); err != nil {
@@ -65,7 +65,7 @@ func TestJSONRawMessage(t *testing.T) {
 			if diff := cmp.Diff(string(json.RawMessage(payload)), string(n)); diff != "" {
 				t.Errorf("jsonb mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, n); err != nil {
+			if _, err := db.Exec(`SELECT jsonb_typeof($1)`, n); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -78,7 +78,7 @@ func TestJSONRawMessage(t *testing.T) {
 		if diff := cmp.Diff(false, n.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT $1`, n); err != nil {
+		if _, err := db.Exec(`SELECT json_typeof($1)`, n); err != nil {
 			t.Fatal(err)
 		}
 		if err := db.QueryRow(`SELECT NULL::jsonb`).Scan(&n); err != nil {
@@ -87,7 +87,7 @@ func TestJSONRawMessage(t *testing.T) {
 		if diff := cmp.Diff(false, n.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT $1`, n); err != nil {
+		if _, err := db.Exec(`SELECT jsonb_typeof($1)`, n); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/tests/json_test.go
+++ b/tests/json_test.go
@@ -87,7 +87,7 @@ func TestJSONRawMessage(t *testing.T) {
 		if diff := cmp.Diff(false, n.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT $1`, n); err != nil {
+		if _, err := db.Exec(`SELECT jsonb_typeof($1)`, n); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/tests/macaddr8_test.go
+++ b/tests/macaddr8_test.go
@@ -61,6 +61,9 @@ func TestMacaddr8(t *testing.T) {
 			if diff := cmp.Diff(addr.output, cidr.Addr.String()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
+			if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 	t.Run("NULL", func(t *testing.T) {
@@ -70,6 +73,9 @@ func TestMacaddr8(t *testing.T) {
 		}
 		if diff := cmp.Diff(false, cidr.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
+		}
+		if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/tests/macaddr8_test.go
+++ b/tests/macaddr8_test.go
@@ -61,7 +61,7 @@ func TestMacaddr8(t *testing.T) {
 			if diff := cmp.Diff(addr.output, cidr.Addr.String()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT trunc($1:macaddr8)`, cidr); err != nil {
+			if _, err := db.Exec(`SELECT trunc($1::macaddr8)`, cidr); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/tests/macaddr8_test.go
+++ b/tests/macaddr8_test.go
@@ -61,7 +61,7 @@ func TestMacaddr8(t *testing.T) {
 			if diff := cmp.Diff(addr.output, cidr.Addr.String()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+			if _, err := db.Exec(`SELECT trunc($1:macaddr8)`, cidr); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -74,7 +74,7 @@ func TestMacaddr8(t *testing.T) {
 		if diff := cmp.Diff(false, cidr.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+		if _, err := db.Exec(`SELECT trunc($1::macaddr8)`, cidr); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/tests/macaddr_test.go
+++ b/tests/macaddr_test.go
@@ -55,6 +55,9 @@ func TestMacaddr(t *testing.T) {
 			if diff := cmp.Diff(addr.output, cidr.Addr.String()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
+			if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 	t.Run("NULL", func(t *testing.T) {
@@ -64,6 +67,9 @@ func TestMacaddr(t *testing.T) {
 		}
 		if diff := cmp.Diff(false, cidr.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
+		}
+		if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/tests/macaddr_test.go
+++ b/tests/macaddr_test.go
@@ -55,7 +55,7 @@ func TestMacaddr(t *testing.T) {
 			if diff := cmp.Diff(addr.output, cidr.Addr.String()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
-			if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+			if _, err := db.Exec(`SELECT trunc($1::macaddr)`, cidr); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -68,7 +68,7 @@ func TestMacaddr(t *testing.T) {
 		if diff := cmp.Diff(false, cidr.Valid); diff != "" {
 			t.Errorf("valid mismatch (-want +got):\n%s", diff)
 		}
-		if _, err := db.Exec(`SELECT $1`, cidr); err != nil {
+		if _, err := db.Exec(`SELECT trunc($1::macaddr)`, cidr); err != nil {
 			t.Fatal(err)
 		}
 	})


### PR DESCRIPTION
Update all tests to exercise the Value method. My first pass at the tests just included a `SELECT $1` which was failing on PostgreSQL 9.6 with the following error:

```
pq: could not determine data type of parameter $1
```

Fixes #1 