### PR TITLE
Implement CIDR.Value() to make it possible to send it to the database

### DIFF
--- a/cidr.go
+++ b/cidr.go
@@ -1,6 +1,9 @@
 package pqtype
 
-import "fmt"
+import (
+	"database/sql/driver"
+	"fmt"
+)
 
 type CIDR Inet
 
@@ -30,4 +33,8 @@ func (dst *CIDR) Scan(src interface{}) error {
 	}
 
 	return fmt.Errorf("cannot scan %T", src)
+}
+
+func (src CIDR) Value() (driver.Value, error) {
+	return Inet(src).Value()
 }


### PR DESCRIPTION
Go doesn't inherit functions from its base type (unless you embed it in
a struct, but that'd be a backwards incompatible change) so we need to
explicitly implement .Value()

Requested on https://github.com/kyleconroy/sqlc/issues/1588